### PR TITLE
feat: add analysis results creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ tests/test_data/**/*analysis.json
 test-results.xml
 report.html
 result/
+
+# Generated Report Files
+protocols_and_analyses.md
+protocols_and_analyses.zip

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,7 @@ inputs:
     type: string
 runs:
   using: 'docker'
-  # image: 'docker://ghcr.io/y3rsh/ot-analyze:main'
-  image: 'Dockerfile'  # For development
+  image: 'docker://ghcr.io/y3rsh/ot-analyze:main'
 branding:
   icon: 'check-square'
   color: 'white'

--- a/action.yml
+++ b/action.yml
@@ -7,15 +7,7 @@ inputs:
     description: 'relative path in the repository of the root folder in which to search for to search for protocols'
     required: false
     default: 'protocols'
-  OUTPUT_TYPE:
-    type: choice
-    description: 'type of output the action generates'
-    required: false
-    default: 'none'
-    options:
-      - 'none'
-      - 'zip'
-      - 'markdown'
+    type: string
 runs:
   using: 'docker'
   # image: 'docker://ghcr.io/y3rsh/ot-analyze:main'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ inputs:
     default: 'protocols'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/y3rsh/ot-analyze:main'
+  # image: 'docker://ghcr.io/y3rsh/ot-analyze:main'
+  image: 'Dockerfile'  # For development
 branding:
   icon: 'check-square'
   color: 'white'

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,15 @@ inputs:
     description: 'relative path in the repository of the root folder in which to search for to search for protocols'
     required: false
     default: 'protocols'
+  OUTPUT_TYPE:
+    type: choice
+    description: 'type of output the action generates'
+    required: false
+    default: 'none'
+    options:
+      - 'none'
+      - 'zip'
+      - 'markdown'
 runs:
   using: 'docker'
   # image: 'docker://ghcr.io/y3rsh/ot-analyze:main'

--- a/ot_analyze.py
+++ b/ot_analyze.py
@@ -3,10 +3,17 @@ import os
 import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from enum import Enum, auto
 from pathlib import Path
 from typing import List
 
 from write_failed_analysis import write_failed_analysis
+
+
+class OutputType(Enum):
+    NONE = auto()
+    ZIP = auto()
+    MARKDOWN = auto()
 
 
 def generate_analysis_path(protocol_file: Path) -> Path:
@@ -107,10 +114,23 @@ def find_pd_protocols(directory: Path) -> List[Path]:
     filtered_json_files = [file for file in json_files if has_designer_application(file)]
     return filtered_json_files
 
+def get_output_type() -> OutputType:
+    """Get the output type from the environment variable OUTPUT_TYPE"""
+    if os.getenv("OUTPUT_TYPE") == "markdown":
+        output_type = OutputType.MARKDOWN
+    elif os.getenv("OUTPUT_TYPE") == "zip":
+        output_type = OutputType.ZIP
+    elif os.getenv("OUTPUT_TYPE") == "none":
+        output_type = OutputType.NONE
+    else:
+        print(f'Invalid OUTPUT_TYPE: {os.getenv("OUTPUT_TYPE")}. Defaulting to "none"')
+        output_type = OutputType.NONE
+    return output_type
+
 
 def main():
     repo_relative_path = Path(os.getenv("GITHUB_WORKSPACE"), os.getenv("INPUT_BASE_DIRECTORY"))
-    print("Hello World")
+    print(f"Using output type: {get_output_type().name.capitalize()}")
     print(f"Analyzing all protocol files in {repo_relative_path}")
     python_files = find_python_protocols(repo_relative_path)
     pd_files = find_pd_protocols(repo_relative_path)

--- a/ot_analyze.py
+++ b/ot_analyze.py
@@ -12,7 +12,8 @@ from typing import Any, Dict, Iterator, List
 
 from write_failed_analysis import write_failed_analysis
 
-FILE_BASENAME = "protocols_and_analyses"
+ZIP_FILE_BASENAME = "protocols_and_analyses"
+MARKDOWN_FILE_BASENAME = "summary"
 
 SUCCESS_COLOR = "#7beb73"
 FAILURE_COLOR = "#eb7373"
@@ -210,7 +211,7 @@ def find_protocol_paths(repo_relative_path: Path) -> List[ProtocolPaths]:
 def create_zip(directory_path: Path):
     absolute_directory_path = directory_path.absolute()
     try:
-        archive_name = shutil.make_archive(FILE_BASENAME, 'zip', absolute_directory_path, absolute_directory_path)
+        archive_name = shutil.make_archive(ZIP_FILE_BASENAME, 'zip', absolute_directory_path, absolute_directory_path)
         print(f"Zipfile created and saved to: {absolute_directory_path / archive_name}")
 
     except Exception as e:
@@ -242,9 +243,9 @@ def create_markdown(protocol_paths: List[ProtocolPaths]) -> None:
     markdown_content = MARKDOWN_TEMPLATE.format(
         results="\n".join([generate_result(protocol_path) for protocol_path in protocol_paths]),
     )
-    markdown_file_name = f"{FILE_BASENAME}.md"
+    markdown_file_name = f"{MARKDOWN_FILE_BASENAME}.md"
     absolute_directory_path = Path.cwd()
-    with open(FILE_BASENAME + ".md", "w") as file:
+    with open(markdown_file_name, "w") as file:
         file.write(markdown_content)
         print(f"Markdown file created and saved to: {absolute_directory_path / markdown_file_name}")
 

--- a/ot_analyze.py
+++ b/ot_analyze.py
@@ -171,5 +171,27 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import contextlib
+
+    @contextlib.contextmanager
+    def set_env(**environ: Dict[str, str]) -> Iterator[None]:
+        old_environ = dict(os.environ)
+        os.environ.update(environ)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(old_environ)
+
+    environ_vars_to_add = {}
+    if os.getenv("GITHUB_WORKSPACE") is None:
+        environ_vars_to_add["GITHUB_WORKSPACE"] = str(Path(__file__).parent.absolute())
+
+    if os.getenv("INPUT_BASE_DIRECTORY") is None:
+        environ_vars_to_add["INPUT_BASE_DIRECTORY"] = "../ot-analyze-test/protocols"
+    if len(environ_vars_to_add) > 0:
+        print(f"Running with the following temporary environment variables: {environ_vars_to_add}")
+
+    with set_env(**environ_vars_to_add):
+        main()
 

--- a/ot_analyze.py
+++ b/ot_analyze.py
@@ -110,6 +110,7 @@ def find_pd_protocols(directory: Path) -> List[Path]:
 
 def main():
     repo_relative_path = Path(os.getenv("GITHUB_WORKSPACE"), os.getenv("INPUT_BASE_DIRECTORY"))
+    print("Hello World")
     print(f"Analyzing all protocol files in {repo_relative_path}")
     python_files = find_python_protocols(repo_relative_path)
     pd_files = find_pd_protocols(repo_relative_path)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from ot_analyze import analyze, generate_analysis_path
+from ot_analyze import analyze, generate_analysis_path, ProtocolPaths
 
 import test_data.data as td
 
@@ -27,30 +27,36 @@ def check_errors_in_analysis(analysis: Path):
 
 
 def test_analyze_ot2_positive():
-    analyze(td.POSITIVE_OT2)
-    check_no_errors_in_analysis(generate_analysis_path(td.POSITIVE_OT2))
+    protocol_path = ProtocolPaths(td.POSITIVE_OT2, generate_analysis_path(td.POSITIVE_OT2))
+    analyze(protocol_path)
+    check_no_errors_in_analysis(protocol_path.analysis_file)
 
 
 def test_analyze_flex_positive():
-    analyze(td.POSITIVE_FLEX)
-    check_no_errors_in_analysis(generate_analysis_path(td.POSITIVE_FLEX))
+    protocol_path = ProtocolPaths(td.POSITIVE_FLEX, generate_analysis_path(td.POSITIVE_FLEX))
+    analyze(protocol_path)
+    check_no_errors_in_analysis(protocol_path.analysis_file)
 
 
 def test_analyze_ot2_negative():
-    analyze(td.ERROR)
-    check_errors_in_analysis(generate_analysis_path(td.ERROR))
+    protocol_path = ProtocolPaths(td.ERROR, generate_analysis_path(td.ERROR))
+    analyze(protocol_path)
+    check_errors_in_analysis(protocol_path.analysis_file)
 
 
 def test_analyze_flex_negative():
-    analyze(td.FLEX_ERROR)
-    check_errors_in_analysis(generate_analysis_path(td.FLEX_ERROR))
+    protocol_path = ProtocolPaths(td.FLEX_ERROR, generate_analysis_path(td.FLEX_ERROR))
+    analyze(protocol_path)
+    check_errors_in_analysis(protocol_path.analysis_file)
 
 
 def test_analyze_json_positive():
-    analyze(td.JSON_POSITIVE)
-    check_no_errors_in_analysis(generate_analysis_path(td.JSON_POSITIVE))
+    protocol_path = ProtocolPaths(td.JSON_POSITIVE, generate_analysis_path(td.JSON_POSITIVE))
+    analyze(protocol_path)
+    check_no_errors_in_analysis(protocol_path.analysis_file)
 
 
 def test_analyze_json_error():
-    analyze(td.JSON_ERROR)
-    check_errors_in_analysis(generate_analysis_path(td.JSON_ERROR))
+    protocol_path = ProtocolPaths(td.JSON_ERROR, generate_analysis_path(td.JSON_ERROR))
+    analyze(protocol_path)
+    check_errors_in_analysis(protocol_path.analysis_file)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from ot_analyze import analyze, generate_analysis_path, ProtocolPaths
+from ot_analyze import ProtocolPaths, analyze, generate_analysis_path
 
 import test_data.data as td
 


### PR DESCRIPTION
# Description

This change adds the creation of:
- `protocols_and_analyses.zip` - This file contains all the protocols and their respective analysis results zipped together
- `summary.md` - This file provides a summary of what is in the zip file. 

`summary.md` contains the following information: 
- A list of all protocols ran
- Whether analysis passed for each protocol
- If the analysis failed, a simplified version of the error
- The elapsed time it took to execute the analysis

# Changes

There aren't many large changes to the existing functionality. The main change to existing functionality is the added `ProtocolPaths` dataclass.

Each protocol becomes an instance of this dataclass, and contains the following: 
- The path to the protocol file
- The path to the analysis file
- The amount of time analysis took to execute
- Various helper methods used in generating the markdown file

The way this changed the functionality was to, generate the expected analysis paths after the protocol paths were generated. This logic was pulled out of the `analyze` function and instead added inside of the `main` function. This was done to make the pairing of the protocol and its respective analysis file easier. This pairing is utilized when generating the markdown file to group each result by protocol name.

The other functionality is mainly additions that don't directly interact with the main functionality of analyzing a protocol.

# Testing

I modified the existing tests to use the `ProtocolPaths` dataclass.

Besides that I didn't add any testing, didn't think it was worth it to ensure the markdown was created correctly at this point. 

I could unzip one of the created zipfiles. But all I am doing is using `shutil.make_archive` to create the entire thing. There is basically no logic at all for this.